### PR TITLE
Converted PLUGINLIB_DECLARE_CLASS to PLUGINLIB_EXPORT_CLASS

### DIFF
--- a/pr2_moveit_plugins/pr2_gripper_controller/src/pr2_gripper_trajectory_controller_handler.cpp
+++ b/pr2_moveit_plugins/pr2_gripper_controller/src/pr2_gripper_trajectory_controller_handler.cpp
@@ -124,6 +124,4 @@ void Pr2GripperTrajectoryControllerHandler::controllerFeedbackCallback(const pr2
 
 }
 
-PLUGINLIB_DECLARE_CLASS(pr2_gripper_controller, Pr2GripperTrajectoryControllerHandler,
-                        pr2_gripper_controller::Pr2GripperTrajectoryControllerHandler,
-                        trajectory_execution::TrajectoryControllerHandler);
+PLUGINLIB_EXPORT_CLASS( pr2_gripper_controller::Pr2GripperTrajectoryControllerHandler, trajectory_execution::TrajectoryControllerHandler);


### PR DESCRIPTION
to remove depreciated warnings
