### PR TITLE
do not load urdf & srdf from pr2_description

### DIFF
--- a/pr2_moveit_config/launch/demo.launch
+++ b/pr2_moveit_config/launch/demo.launch
@@ -1,7 +1,5 @@
 <launch>
 
-  <include file="$(find pr2_description)/robots/upload_pr2.launch"/>
-
   <node pkg="tf" type="static_transform_publisher" name="odom_broadcaster" args="0 0 0 0 0 0 odom_combined base_footprint 100" />
 
 


### PR DESCRIPTION
These are now loaded by planning_context.launch in
the pr2_moveit_config package.
