### PR TITLE
Fixes to gripper controller, new object recognition launch file

### DIFF
--- a/pr2_moveit_config/config/detection.ork
+++ b/pr2_moveit_config/config/detection.ork
@@ -1,0 +1,60 @@
+source1:
+  type: RosKinect
+  module: 'object_recognition_ros.io'
+  #
+  # Example parameters to set (the default settings are using the ros topics starting with /camera/....) 
+  #  
+  parameters:
+    rgb_image_topic: /head_mount_kinect/rgb/image_color
+    rgb_camera_info: /head_mount_kinect/rgb/camera_info
+    depth_image_topic: /head_mount_kinect/depth_registered/image_rect
+    depth_camera_info: /head_mount_kinect/depth_registered/camera_info
+    #
+    #crop_enabled: True
+    #x_min: -0.4
+    #x_max: 0.4
+    #y_min: -1.0
+    #y_max: 0.2
+    #z_min: 0.3
+    #z_max: 1.5
+  
+sink1:
+  type: TablePublisher
+  module: 'object_recognition_tabletop'
+  inputs: [source1]
+
+sink2:
+  type: Publisher
+  module: 'object_recognition_ros.io'
+  inputs: [source1]
+
+
+pipeline1:
+  type: TabletopTableDetector
+  module: 'object_recognition_tabletop'
+  inputs: [source1]
+  outputs: [sink1]
+  parameters:
+    table_detector:
+        min_table_size: 4000
+        plane_threshold: 0.01
+    #clusterer:
+    #    table_z_filter_max: 0.35
+    #    table_z_filter_min: 0.025
+
+pipeline2:
+  type: TabletopObjectDetector
+  module: 'object_recognition_tabletop'
+  inputs: [source1, pipeline1]
+  outputs: [sink2]
+  parameters:
+    object_ids: 'all'
+    tabletop_object_ids: 'REDUCED_MODEL_SET'
+    db:
+      type: 'ObjectDbSqlHousehold'
+      host: 'localhost'
+      port: 5432
+      user: 'willow'
+      password: 'willow'
+      name: 'household_objects'
+      module: 'object_recognition_tabletop'

--- a/pr2_moveit_config/launch/pr2_moveit_sensor_manager.launch
+++ b/pr2_moveit_config/launch/pr2_moveit_sensor_manager.launch
@@ -19,7 +19,7 @@
   <!-- Params for the octomap monitor -->
   
   <param name="octomap_frame" type="string" value="odom_combined" />
-  <param name="octomap_resolution" type="double" value="0.05" />
+  <param name="octomap_resolution" type="double" value="0.025" />
   <param name="max_range" type="double" value="5.0" />
   
   <!-- sensors used to update the map -->

--- a/pr2_moveit_config/launch/tabletop_object_recognition.launch
+++ b/pr2_moveit_config/launch/tabletop_object_recognition.launch
@@ -23,7 +23,7 @@
   <include file="$(find object_recognition_ros)/launch/object_information_server.launch" />
 
   <!-- Start the node that publishes updates to the planning scene based on detected objects -->
-  <node name="populate_moveit_planning_scene_from_ork" pkg="moveit_ork" type="moveit_planning_scene_from_ork.py" respawn="true" output="screen" args="--min-confidence $(arg min_confidence) --auto-trigger $(arg trigger_period)">
+  <node name="populate_moveit_planning_scene_from_ork" pkg="moveit_ork" type="moveit_planning_scene_from_ork.py" respawn="true" output="screen" args="--min-confidence $(arg min_confidence)">
   </node>
   
 </launch>

--- a/pr2_moveit_config/launch/tabletop_object_recognition.launch
+++ b/pr2_moveit_config/launch/tabletop_object_recognition.launch
@@ -1,4 +1,7 @@
 <launch>
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <!-- How often (seconds) to trigger object recognition -->
   <arg name="trigger_period" default="1.0" />  
@@ -7,7 +10,14 @@
   <arg name="min_confidence" default="0.5" />  
 
   <!-- Start the recognition pipeline -->
-  <include file="$(find object_recognition_tabletop)/launch/tabletop.launch" />
+  <node name="recognize_tabletop_objects_server" launch-prefix="$(arg launch_prefix)" pkg="object_recognition_ros" type="server" respawn="false" output="screen" args="--node_name tabletop_object_recognition -c $(find pr2_moveit_config)/config/detection.ork">    
+    <remap from="/camera/rgb/camera_info" to="/head_mount_kinect/rgb/camera_info"/>
+    <remap from="/camera/rgb/image_rect_color" to="/head_mount_kinect/rgb/image_rect_color"/>
+    <remap from="/camera/rgb/image_color" to="/head_mount_kinect/rgb/image_color"/>
+    <remap from="/camera/depth_registered/camera_info" to="/head_mount_kinect/depth_registered/camera_info"/>
+    <remap from="/camera/depth_registered/image_rect" to="/head_mount_kinect/depth_registered/image_rect"/>
+    <remap from="/camera/depth_registered/image" to="/head_mount_kinect/depth_registered/image"/>
+  </node>
 
   <!-- Start the service that can answer questions about object types -->
   <include file="$(find object_recognition_ros)/launch/object_information_server.launch" />

--- a/pr2_moveit_plugins/pr2_moveit_controller_manager/src/pr2_moveit_controller_manager.cpp
+++ b/pr2_moveit_plugins/pr2_moveit_controller_manager/src/pr2_moveit_controller_manager.cpp
@@ -14,7 +14,7 @@
 *     copyright notice, this list of conditions and the following
 *     disclaimer in the documentation and/or other materials provided
 *     with the distribution.
-*   * Neither the name of the Willow Garage nor the names of its
+*   * Neither the name of Willow Garage, Inc. nor the names of its
 *     contributors may be used to endorse or promote products derived
 *     from this software without specific prior written permission.
 *
@@ -53,6 +53,10 @@ namespace pr2_moveit_controller_manager
 static const double DEFAULT_MAX_GRIPPER_EFFORT = 10000.0;
 static const double GRIPPER_OPEN = 0.086;
 static const double GRIPPER_CLOSED = 0.0;
+  //static const unsigned int FULL_GRIPPER_CMD_INDEX = 1;
+  //static const unsigned int VIRTUAL_GRIPPER_CMD_INDEX = 0;
+  //static const unsigned int FULL_GRIPPER_CMD_MIN_SIZE = 2;
+static const double GAP_CONVERSION_RATIO = 0.1714;
 
 template<typename T>
 class ActionBasedControllerHandle : public moveit_controller_manager::MoveItControllerHandle
@@ -163,13 +167,34 @@ public:
     pr2_controllers_msgs::Pr2GripperCommandGoal goal;
     goal.command.max_effort = DEFAULT_MAX_GRIPPER_EFFORT;
 
-    bool open = false;
-    for (std::size_t i = 0 ; i < trajectory.joint_trajectory.points.back().positions.size() ; ++i)
-      if (trajectory.joint_trajectory.points.back().positions[i] > 0.5)
+    int gripper_joint_index = -1;
+    for(std::size_t i=0; i < trajectory.joint_trajectory.joint_names.size(); ++i)
+    {
+      if(trajectory.joint_trajectory.joint_names[i] == "r_gripper_joint" || trajectory.joint_trajectory.joint_names[i] == "l_gripper_joint")
       {
-    open = true;
-    break;
+	gripper_joint_index = i;
+	break;
       }
+    }
+    
+    if(gripper_joint_index == -1)
+    {
+      ROS_ERROR("Could not find value for gripper virtual joint");
+      return false;
+    }
+
+    double gap_opening = trajectory.joint_trajectory.points.back().positions[gripper_joint_index]*GAP_CONVERSION_RATIO;
+    ROS_DEBUG("Gap opening: %f", gap_opening);        
+    closing_ = false;
+
+    /*
+    bool open = false;
+    if (gap_opening > GRIPPER_OPEN)
+      gap_opening = GRIPPER_OPEN;
+    else if (gap_opening <= 0.0)
+    {
+      open = true;
+    }
 
     if (open)
     {
@@ -183,7 +208,22 @@ public:
       closing_ = true;
       ROS_DEBUG_STREAM("Sending gripper close command");
     }
+    */
 
+    if(gap_opening > GRIPPER_OPEN)
+    {
+      gap_opening = GRIPPER_OPEN;
+      closing_ = false;
+    }
+    if(gap_opening <=0)
+    {
+      gap_opening = 0.0;
+      closing_ = true;
+    }
+    else
+      closing_ = false;
+
+    goal.command.position = gap_opening;
     controller_action_client_->sendGoal(goal,
                     boost::bind(&Pr2GripperControllerHandle::controllerDoneCallback, this, _1, _2),
                     boost::bind(&Pr2GripperControllerHandle::controllerActiveCallback, this),

--- a/pr2_moveit_plugins/pr2_moveit_controller_manager/src/pr2_moveit_controller_manager.cpp
+++ b/pr2_moveit_plugins/pr2_moveit_controller_manager/src/pr2_moveit_controller_manager.cpp
@@ -196,13 +196,11 @@ public:
       gap_opening = GRIPPER_OPEN;
       closing_ = false;
     }
-    if(gap_opening <=0)
+    else if(gap_opening <=0.0)
     {
       gap_opening = 0.0;
       closing_ = true;
     }
-    else
-      closing_ = false;
 
     goal.command.position = gap_opening;
     controller_action_client_->sendGoal(goal,

--- a/pr2_moveit_plugins/pr2_moveit_controller_manager/src/pr2_moveit_controller_manager.cpp
+++ b/pr2_moveit_plugins/pr2_moveit_controller_manager/src/pr2_moveit_controller_manager.cpp
@@ -170,13 +170,19 @@ public:
     int gripper_joint_index = -1;
     for(std::size_t i=0; i < trajectory.joint_trajectory.joint_names.size(); ++i)
     {
-      if(trajectory.joint_trajectory.joint_names[i] == "r_gripper_joint" || trajectory.joint_trajectory.joint_names[i] == "l_gripper_joint")
+      if(trajectory.joint_trajectory.joint_names[i] == "r_gripper_motor_screw_joint" || trajectory.joint_trajectory.joint_names[i] == "l_gripper_motor_screw_joint")
       {
 	gripper_joint_index = i;
 	break;
       }
     }
     
+    for(std::size_t i=0; i < trajectory.joint_trajectory.joint_names.size(); ++i)
+    {
+      ROS_DEBUG("Gripper trajectory (%d): %s %f", (int) i, trajectory.joint_trajectory.joint_names[i].c_str(), trajectory.joint_trajectory.points[0].positions[i]);
+    }
+    ROS_DEBUG(" ");
+
     if(gripper_joint_index == -1)
     {
       ROS_ERROR("Could not find value for gripper virtual joint");
@@ -184,7 +190,7 @@ public:
     }
 
     double gap_opening = trajectory.joint_trajectory.points.back().positions[gripper_joint_index]*GAP_CONVERSION_RATIO;
-    ROS_DEBUG("Gap opening: %f", gap_opening);        
+    ROS_INFO("Gap opening: %f", gap_opening);        
     closing_ = false;
 
     /*

--- a/pr2_moveit_plugins/pr2_moveit_controller_manager/src/pr2_moveit_controller_manager.cpp
+++ b/pr2_moveit_plugins/pr2_moveit_controller_manager/src/pr2_moveit_controller_manager.cpp
@@ -190,7 +190,7 @@ public:
     }
 
     double gap_opening = trajectory.joint_trajectory.points.back().positions[gripper_joint_index]*GAP_CONVERSION_RATIO;
-    ROS_INFO("Gap opening: %f", gap_opening);        
+    ROS_DEBUG("Gap opening: %f", gap_opening);        
     closing_ = false;
 
     /*

--- a/pr2_moveit_plugins/pr2_moveit_controller_manager/src/pr2_moveit_controller_manager.cpp
+++ b/pr2_moveit_plugins/pr2_moveit_controller_manager/src/pr2_moveit_controller_manager.cpp
@@ -53,9 +53,6 @@ namespace pr2_moveit_controller_manager
 static const double DEFAULT_MAX_GRIPPER_EFFORT = 10000.0;
 static const double GRIPPER_OPEN = 0.086;
 static const double GRIPPER_CLOSED = 0.0;
-  //static const unsigned int FULL_GRIPPER_CMD_INDEX = 1;
-  //static const unsigned int VIRTUAL_GRIPPER_CMD_INDEX = 0;
-  //static const unsigned int FULL_GRIPPER_CMD_MIN_SIZE = 2;
 static const double GAP_CONVERSION_RATIO = 0.1714;
 
 template<typename T>
@@ -193,28 +190,6 @@ public:
     ROS_DEBUG("Gap opening: %f", gap_opening);        
     closing_ = false;
 
-    /*
-    bool open = false;
-    if (gap_opening > GRIPPER_OPEN)
-      gap_opening = GRIPPER_OPEN;
-    else if (gap_opening <= 0.0)
-    {
-      open = true;
-    }
-
-    if (open)
-    {
-      goal.command.position = GRIPPER_OPEN;
-      closing_ = false;
-      ROS_DEBUG_STREAM("Sending gripper open command");
-    }
-    else
-    {
-      goal.command.position = GRIPPER_CLOSED;
-      closing_ = true;
-      ROS_DEBUG_STREAM("Sending gripper close command");
-    }
-    */
 
     if(gap_opening > GRIPPER_OPEN)
     {


### PR DESCRIPTION
This adds a fix to the gripper controller (takes out unnecessary constants and searches for the right joint name), a new object recognition launch and config file (to map topics correctly we do it here instead of in the ork launch files).
