### PR TITLE
Changed a tutorial title to better match text and external links.

### DIFF
--- a/pr2_moveit_tutorials/planning/src/doc/index.rst
+++ b/pr2_moveit_tutorials/planning/src/doc/index.rst
@@ -1,4 +1,4 @@
-Environment Representation/C++ API
+Planning Scene/C++ API
 ==================================
 The :planning_scene:`PlanningScene` class provides the main interface that you will use
 for collision checking and constraint checking. In this tutorial, we


### PR DESCRIPTION
Changed title of planning tutorial from 'Environment Representation' to 'Planning Scene'.  Links pointing to this tutorial all seem to be called "Planning Scene", so changing the page title to match that.
