### PR TITLE
update demo.launch for using actual robot

### DIFF
--- a/pr2_moveit_config/launch/demo.launch
+++ b/pr2_moveit_config/launch/demo.launch
@@ -1,25 +1,42 @@
 <launch>
+  <arg name="db" default="false" />
+  <arg name="debug" default="false" />
+  <arg name="rviz" default="true" />
+  <arg name="load_robot_description" default="true" />
+  <arg name="use_actual_robot" default="false" />
+  <arg name="moveit_octomap_sensor_params_file"
+       default="$(find pr2_moveit_config)/config/sensors_kinect.yaml" />
+
+  <arg     if="$(arg use_actual_robot)" name="simulation_mode" value="false" />
+  <arg unless="$(arg use_actual_robot)" name="simulation_mode" value="true" />
 
   <include file="$(find pr2_moveit_config)/launch/planning_context.launch">
-    <arg name="load_robot_description" value="true"/>
+    <arg name="load_robot_description" value="$(arg load_robot_description)"/>
   </include>
 
-  <node pkg="tf" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 odom_combined base_footprint 100" />
+  <node unless="$(arg use_actual_robot)"
+        pkg="tf" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 odom_combined base_footprint 100" />
 
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="true"/>
+  <node unless="$(arg use_actual_robot)"
+        name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+    <param name="/use_gui" value="false"/>
+    <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
   </node>
-  
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
+
+  <node unless="$(arg use_actual_robot)"
+        name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <include file="$(find pr2_moveit_config)/launch/move_group.launch">
-    <arg name="allow_trajectory_execution" value="false"/>
+    <arg name="allow_trajectory_execution" value="$(arg use_actual_robot)"/>
+    <arg name="info" value="true"/>
+    <arg name="debug" value="$(arg debug)"/>
+    <arg name="moveit_octomap_sensor_params_file" value="$(arg moveit_octomap_sensor_params_file)"/>
   </include>
 
-  <include file="$(find pr2_moveit_config)/launch/moveit_rviz.launch">
+  <include file="$(find pr2_moveit_config)/launch/moveit_rviz.launch" if="$(arg rviz)">
     <arg name="config" value="true"/>
   </include>
 
-  <include file="$(find pr2_moveit_config)/launch/default_warehouse_db.launch" />
+  <include file="$(find pr2_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)"/>
 
 </launch>


### PR DESCRIPTION
I added the same arguments in demo.launch in hydro-devel and added use_actual_robot for using actual robot(PR2) with demo.launch .
Target branch was changed from https://github.com/ros-planning/moveit_pr2/pull/46 
