### PR TITLE
Fixed test failures that happen when moveit include files change.

### DIFF
--- a/pr2_moveit_tests/CMakeLists.txt
+++ b/pr2_moveit_tests/CMakeLists.txt
@@ -17,6 +17,9 @@ find_package(catkin REQUIRED
 find_package(PkgConfig REQUIRED)
 find_package(Boost REQUIRED system filesystem date_time thread)
 
+## Specify additional locations of header files
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+
 pkg_check_modules(FCL REQUIRED fcl)
 include_directories(${FCL_INCLUDE_DIRS})
 link_directories(${FCL_LIBRARY_DIRS})
@@ -25,11 +28,7 @@ pkg_check_modules(OCTOMAP REQUIRED octomap)
 include_directories(${OCTOMAP_INCLUDE_DIRS})
 link_directories(${OCTOMAP_LIBRARY_DIRS})
 
-
 ## Declare things to be passed to other projects
 catkin_package()
-
-## Specify additional locations of header files
-include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 add_subdirectory(kinematics)


### PR DESCRIPTION
Before this, the pr2_moveit_tests would use moveit include files from /opt/ros/hydro
instead of those from the current catkin workspace.  That meant that any time one of those
include files changed, tests would fail here because they would use the wrong versions of
the include files.
