### PR TITLE
add arms_and_torso group

### DIFF
--- a/pr2_moveit_config/config/pr2.srdf
+++ b/pr2_moveit_config/config/pr2.srdf
@@ -35,6 +35,10 @@
     <group name="torso">
         <joint name="torso_lift_joint" />
     </group>
+    <group name="arms_and_torso">
+        <group name="arms" />
+        <group name="torso" />
+    </group>
     <group name="whole_body">
         <group name="base" />
         <group name="arms" />


### PR DESCRIPTION
Add arms_and_torso group in config file.
It is needed for manipulation planning without base.
