### PR TITLE
pr2_moveit_tutorials/package.xml add run_depends

### DIFF
--- a/pr2_moveit_tutorials/package.xml
+++ b/pr2_moveit_tutorials/package.xml
@@ -25,5 +25,8 @@
   <run_depend>moveit_ros_planning_interface</run_depend>
   <run_depend>moveit_ros_perception</run_depend>
   <run_depend>interactive_markers</run_depend>
+  <run_depend>pr2_arm_kinematics</run_depend>
+  <run_depend>pr2_moveit_config</run_depend>
+  <run_depend>pr2_moveit_plugins</run_depend>
 
 </package>


### PR DESCRIPTION
`pr2_moveit_tutorials/package.xml` was missing some `run_depend`
tags on pr2 kinematics, moveit config, and moveit plugins
