### PR TITLE
made jiggle_fraction parameter usable from outside

### DIFF
--- a/pr2_moveit_config/launch/move_group.launch
+++ b/pr2_moveit_config/launch/move_group.launch
@@ -13,6 +13,7 @@
   <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
   <arg name="max_safe_path_cost" default="1"/>
+  <arg name="jiggle_fraction" default="0.05"/>
   <arg name="publish_monitored_planning_scene" default="true"/>
   <arg name="moveit_octomap_sensor_params_file" default="$(find pr2_moveit_config)/config/sensors_kinect.yaml" />
 
@@ -37,7 +38,7 @@
 
     <param name="allow_trajectory_execution" value="$(arg allow_trajectory_execution)"/>
     <param name="max_safe_path_cost" value="$(arg max_safe_path_cost)"/>
-    <param name="jiggle_fraction" value="0.05" />
+    <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
 
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
 				      move_group/MoveGroupExecuteService


### PR DESCRIPTION
If anyone wants to include move_group.launch and access the jiggle_fraction parameter from the including launch file, they are now able to do this.
