### PR TITLE
Convert deprecated shape_tools dependency

### DIFF
--- a/pr2_moveit_tutorials/CMakeLists.txt
+++ b/pr2_moveit_tutorials/CMakeLists.txt
@@ -4,7 +4,15 @@ project(pr2_moveit_tutorials)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS moveit_core moveit_ros_planning moveit_ros_planning_interface pluginlib cmake_modules)
+find_package(catkin REQUIRED
+             COMPONENTS
+             moveit_core
+             moveit_ros_planning
+             moveit_ros_planning_interface
+             pluginlib
+             cmake_modules
+             geometric_shapes
+)
 
 find_package(Boost REQUIRED system filesystem date_time thread)
 

--- a/pr2_moveit_tutorials/package.xml
+++ b/pr2_moveit_tutorials/package.xml
@@ -18,6 +18,7 @@
   <build_depend>moveit_ros_perception</build_depend>
   <build_depend>interactive_markers</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>geometric_shapes</build_depend>
 
   <run_depend>pluginlib</run_depend>
   <run_depend>moveit_core</run_depend>

--- a/pr2_moveit_tutorials/pick_place/src/pick_place_tutorial.cpp
+++ b/pr2_moveit_tutorials/pick_place/src/pick_place_tutorial.cpp
@@ -39,7 +39,7 @@
 // MoveIt!
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/move_group_interface/move_group.h>
-#include <shape_tools/solid_primitive_dims.h>
+#include <geometric_shapes/solid_primitive_dims.h>
 
 static const std::string ROBOT_DESCRIPTION="robot_description";
 
@@ -166,7 +166,7 @@ int main(int argc, char **argv)
   co.operation = moveit_msgs::CollisionObject::ADD;
   co.primitives.resize(1);
   co.primitives[0].type = shape_msgs::SolidPrimitive::BOX;
-  co.primitives[0].dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value);
+  co.primitives[0].dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value);
   co.primitives[0].dimensions[shape_msgs::SolidPrimitive::BOX_X] = 0.3;
   co.primitives[0].dimensions[shape_msgs::SolidPrimitive::BOX_Y] = 0.1;
   co.primitives[0].dimensions[shape_msgs::SolidPrimitive::BOX_Z] = 1.0;


### PR DESCRIPTION
shape_tools functionality was merged into geometric_shapes:
https://github.com/ros-planning/geometric_shapes/pull/32

Updating the pick and place tutorial and adding geometric_shapes
to the package.xml and CMakeLists.txt.

Because of the most recent release of geometric_shapes (deprecating shape_tools), I believe this fix should remedy the current ROS Buildfarm failure: http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__pr2_moveit_tutorials__ubuntu_trusty_amd64__binary/lastFailedBuild/console
