### PR TITLE
use 'classic' Sphinx style explicitly

### DIFF
--- a/pr2_moveit_tutorials/conf.py
+++ b/pr2_moveit_tutorials/conf.py
@@ -22,6 +22,9 @@ show_authors = True
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# Name of the style used to generate the html documentation
+html_theme = 'default'
+
 extlinks = {'codedir': ('https://github.com/ros-planning/moveit_pr2/blob/hydro-devel/pr2_moveit_tutorials/%s', ''),
             'moveit_core': ('http://docs.ros.org/api/moveit_core/html/classmoveit_1_1core_1_1%s.html', ''),
             'planning_scene': ('http://docs.ros.org/api/moveit_core/html/classplanning__scene_1_1%s.html', ''),


### PR DESCRIPTION
Sphinx 1.4.2+ fail with

> NoSectionError: No section: 'theme'
> if this is not present.

I _suppose_ it does work with the Sphinx bundled older versions shipped
with Ubuntu, but I didn't didn't test that. So please run `rosdoc_lite .`
and check whether the output still looks the same before merging.
