### PR TITLE
Explicitly convert shared_ptr to bool for c++11 compatibility.

### DIFF
--- a/pr2_moveit_plugins/pr2_moveit_controller_manager/src/pr2_moveit_controller_manager.cpp
+++ b/pr2_moveit_plugins/pr2_moveit_controller_manager/src/pr2_moveit_controller_manager.cpp
@@ -93,7 +93,7 @@ public:
 
   bool isConnected() const
   {
-    return controller_action_client_;
+    return static_cast<bool>(controller_action_client_);
   }
 
   virtual bool cancelExecution()


### PR DESCRIPTION
Since C++11 `shared_ptrs` (both boost and standard library versions) have an explicit `operator bool()`, meaning that implicit conversion in return statements don't work anymore.

This PR fixes one such occurence in `pr2_moveit_controller_manager.cpp` by adding an explicit `static_cast<bool>`.
