### PR TITLE
allow to open pr2_moveit_config in setup_assistant

### DIFF
--- a/pr2_moveit_config/.setup_assistant
+++ b/pr2_moveit_config/.setup_assistant
@@ -1,7 +1,7 @@
 moveit_setup_assistant_config:
   URDF:
-    package: pr2_moveit_config
-    relative_path: temp/pr2.urdf
+    package: pr2_description
+    relative_path: robots/pr2.urdf.xacro
   SRDF:
     relative_path: config/pr2.srdf
   CONFIG:


### PR DESCRIPTION
The temp-file does not exist and the moveit_config already run_depends on
pr2_description anyway.
