### PR TITLE
compile with c++11

### DIFF
--- a/pr2_moveit_plugins/CMakeLists.txt
+++ b/pr2_moveit_plugins/CMakeLists.txt
@@ -32,6 +32,8 @@ catkin_package(
     moveit_core
     )
 
+add_compile_options(-std=c++11)
+
 include_directories(pr2_arm_kinematics/include)
 include_directories(pr2_moveit_controller_manager/include)
 include_directories(pr2_moveit_sensor_manager/include)


### PR DESCRIPTION
MoveIt requires c++11 for kinetic upwards.
