### PR TITLE
Remove moveit-tutorials dependency

### DIFF
--- a/moveit_pr2/package.xml
+++ b/moveit_pr2/package.xml
@@ -16,7 +16,6 @@
 
   <run_depend>pr2_moveit_plugins</run_depend>
   <run_depend>pr2_moveit_config</run_depend>
-  <run_depend>pr2_moveit_tutorials</run_depend>
 
   <export>
     <metapackage/>


### PR DESCRIPTION
We no longer release ``ros-indigo-moveit-pr2`` so this missing dependency breaks our [Docker build](https://hub.docker.com/r/moveit/moveit/builds/bcbljonvuuysugq6za8yu3i/). @130s 