### PR TITLE
Add a comment to waypoints in the Cartesian Path chapter

### DIFF
--- a/pr2_moveit_tutorials/planning/scripts/move_group_python_interface_tutorial.py
+++ b/pr2_moveit_tutorials/planning/scripts/move_group_python_interface_tutorial.py
@@ -186,7 +186,9 @@ def move_group_python_interface_tutorial():
   ## for the end-effector to go through.
   waypoints = []
 
-  # start with the current pose
+  # start with the current pose, only for rviz simulation. Remove this step if working
+  # with a real robot, or group.compute_cartesian_path() will complain about "Trajectory
+  # message contains waypoints that are not strictly increasing in time".
   waypoints.append(group.get_current_pose().pose)
 
   # first orient gripper and move forward (+x)


### PR DESCRIPTION
Edit some comments in the Cartesian Paths chapter, to prevent others from making my same mistake of adding the group.get_current_pose().pose as a first waypoint, when working with a non-simulated robot.

As can be seen in multiple stackoverflow questions, like [this one](https://answers.ros.org/question/253004/moveit-problem-error-trajectory-message-contains-waypoints-that-are-not-strictly-increasing-in-time/), this has been a cause for some head-scratching..