### PR TITLE
use urdf typedefs to stay compatible with boost vs std ptrs

### DIFF
--- a/pr2_moveit_plugins/pr2_arm_kinematics/include/moveit/pr2_arm_kinematics/pr2_arm_ik.h
+++ b/pr2_moveit_plugins/pr2_arm_kinematics/include/moveit/pr2_arm_kinematics/pr2_arm_ik.h
@@ -100,7 +100,7 @@ public:
 
   private:
 
-  void addJointToChainInfo(boost::shared_ptr<const urdf::Joint> joint,moveit_msgs::KinematicSolverInfo &info);
+  void addJointToChainInfo(urdf::JointConstSharedPtr joint,moveit_msgs::KinematicSolverInfo &info);
 
   bool checkJointLimits(const std::vector<double> &joint_values) const;
 

--- a/pr2_moveit_plugins/pr2_arm_kinematics/src/pr2_arm_ik.cpp
+++ b/pr2_moveit_plugins/pr2_arm_kinematics/src/pr2_arm_ik.cpp
@@ -57,10 +57,10 @@ bool PR2ArmIK::init(const urdf::Model &robot_model, const std::string &root_name
 {
   std::vector<urdf::Pose> link_offset;
   int num_joints = 0;
-  boost::shared_ptr<const urdf::Link> link = robot_model.getLink(tip_name);
+  urdf::LinkConstSharedPtr link = robot_model.getLink(tip_name);
   while(link && num_joints < 7)
   {
-    boost::shared_ptr<const urdf::Joint> joint;
+    urdf::JointConstSharedPtr joint;
     if (link->parent_joint)
       joint = robot_model.getJoint(link->parent_joint->name);
     if(!joint)
@@ -148,7 +148,7 @@ bool PR2ArmIK::init(const urdf::Model &robot_model, const std::string &root_name
   return true;
 }
 
-void PR2ArmIK::addJointToChainInfo(boost::shared_ptr<const urdf::Joint> joint, moveit_msgs::KinematicSolverInfo &info)
+void PR2ArmIK::addJointToChainInfo(urdf::JointConstSharedPtr joint, moveit_msgs::KinematicSolverInfo &info)
 {
   moveit_msgs::JointLimits limit;
   info.joint_names.push_back(joint->name);//Joints are coming in reverse order

--- a/pr2_moveit_tests/kinematics/src/test_constraint_aware_kinematics.cpp
+++ b/pr2_moveit_tests/kinematics/src/test_constraint_aware_kinematics.cpp
@@ -60,8 +60,8 @@ TEST(ConstraintAwareKinematics, getIK)
   robot_model_loader::RobotModelLoader robot_model_loader("robot_description"); /** Used to load the robot model */
   robot_model::RobotModelPtr kinematic_model = robot_model_loader.getModel();
 
-  const boost::shared_ptr<srdf::Model> &srdf = robot_model_loader.getSRDF();
-  const boost::shared_ptr<urdf::ModelInterface>& urdf_model = robot_model_loader.getURDF();
+  const srdf::ModelSharedPtr& srdf = robot_model_loader.getSRDF();
+  const urdf::ModelInterfaceSharedPtr& urdf_model = robot_model_loader.getURDF();
 
   planning_scene.reset(new planning_scene::PlanningScene(kinematic_model));
 

--- a/pr2_moveit_tests/kinematics/src/test_kinematics_as_plugin.cpp
+++ b/pr2_moveit_tests/kinematics/src/test_kinematics_as_plugin.cpp
@@ -163,8 +163,8 @@ TEST(ArmIKPlugin, getFK)
 {
   rdf_loader::RDFLoader rdf_loader_;
   robot_model::RobotModelPtr kinematic_model;
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_.getSRDF();
-  const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader_.getURDF();
+  const srdf::ModelSharedPtr& srdf = rdf_loader_.getSRDF();
+  const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader_.getURDF();
   kinematic_model.reset(new robot_model::RobotModel(urdf_model, srdf));
   robot_model::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup(my_test.kinematics_solver_->getGroupName());
 
@@ -200,8 +200,8 @@ TEST(ArmIKPlugin, searchIK)
 {
   rdf_loader::RDFLoader rdf_loader_;
   robot_model::RobotModelPtr kinematic_model;
-  const boost::shared_ptr<srdf::Model> &srdf_model = rdf_loader_.getSRDF();
-  const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader_.getURDF();
+  const srdf::ModelSharedPtr& srdf_model = rdf_loader_.getSRDF();
+  const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader_.getURDF();
   kinematic_model.reset(new robot_model::RobotModel(urdf_model, srdf_model));
   robot_model::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup(my_test.kinematics_solver_->getGroupName());
 
@@ -269,8 +269,8 @@ TEST(ArmIKPlugin, searchIKWithCallbacks)
 {
   rdf_loader::RDFLoader rdf_loader_;
   robot_model::RobotModelPtr kinematic_model;
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_.getSRDF();
-  const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader_.getURDF();
+  const srdf::ModelSharedPtr& srdf = rdf_loader_.getSRDF();
+  const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader_.getURDF();
   kinematic_model.reset(new robot_model::RobotModel(urdf_model, srdf));
   robot_model::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup(my_test.kinematics_solver_->getGroupName());
 

--- a/tests/pr2_arm_ik_tests/test/test_kinematics_as_plugin.cpp
+++ b/tests/pr2_arm_ik_tests/test/test_kinematics_as_plugin.cpp
@@ -172,8 +172,8 @@ TEST(ArmIKPlugin, getFK)
 {
   rdf_loader::RDFLoader rdf_loader_;
   robot_model::RobotModelPtr kinematic_model;
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_.getSRDF();
-  const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader_.getURDF();
+  const srdf::ModelSharedPtr& srdf = rdf_loader_.getSRDF();
+  const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader_.getURDF();
   robot_model.reset(new robot_model::RobotModel(urdf_model, srdf));
   robot_model::RobotModel::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup(my_test.kinematics_solver->getGroupName());
 
@@ -211,8 +211,8 @@ TEST(ArmIKPlugin, searchIK)
 {
   rdf_loader::RDFLoader rdf_loader_;
   robot_model::RobotModelPtr kinematic_model;
-  const boost::shared_ptr<srdf::Model> &srdf_model = rdf_loader_.getSRDF();
-  const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader_.getURDF();
+  const srdf::ModelSharedPtr& srdf_model = rdf_loader_.getSRDF();
+  const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader_.getURDF();
   robot_model.reset(new planning_models::RobotModel(urdf_model, srdf));
   planning_models::RobotModel::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup(my_test.kinematics_solver->getGroupName());
 
@@ -281,8 +281,8 @@ TEST(ArmIKPlugin, searchIKWithCallbacks)
 {
   rdf_loader::RDFLoader rdf_loader_;
   planning_models::RobotModelPtr kinematic_model;
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_.getSRDF();
-  const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader_.getURDF();
+  const srdf::ModelSharedPtr& srdf = rdf_loader_.getSRDF();
+  const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader_.getURDF();
   robot_model.reset(new planning_models::RobotModel(urdf_model, srdf));
   planning_models::RobotModel::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup(my_test.kinematics_solver->getGroupName());
 


### PR DESCRIPTION
allow to compile the package with a current version of urdf