### PR TITLE
fix for melodic, same patch as https://github.com/ros-planning/moveit/pull/906/files

### DIFF
--- a/pr2_moveit_plugins/pr2_arm_kinematics/include/moveit/pr2_arm_kinematics/pr2_arm_ik_solver.h
+++ b/pr2_moveit_plugins/pr2_arm_kinematics/include/moveit/pr2_arm_kinematics/pr2_arm_ik_solver.h
@@ -71,6 +71,8 @@ static const int TIMED_OUT = -2;
 
     ~PR2ArmIKSolver(){ delete pr2_arm_ik_; };
 
+    virtual void updateInternalDataStructures();
+
     /**
      * @brief The PR2 inverse kinematics solver
      */

--- a/pr2_moveit_plugins/pr2_arm_kinematics/src/pr2_arm_ik_solver.cpp
+++ b/pr2_moveit_plugins/pr2_arm_kinematics/src/pr2_arm_ik_solver.cpp
@@ -357,3 +357,7 @@ std::string PR2ArmIKSolver::getFrameId()
 {
   return root_frame_name_;
 }
+
+void PR2ArmIKSolver::updateInternalDataStructures()
+{
+}


### PR DESCRIPTION
Without this, we got following error
```
/tmp/hoge/src/moveit_pr2/pr2_moveit_plugins/pr2_arm_kinematics/src/pr2_arm_kinematics_plugin.cpp:93:138: error: invalid new-expression of abstract class type ‘pr2_arm_kinematics::PR2ArmIKSolver’
   pr2_arm_ik_solver_.reset(new pr2_arm_kinematics::PR2ArmIKSolver(robot_model, base_frame_,tip_frame_, search_discretization_,free_angle_));
                                                                                                                                          ^
In file included from /tmp/hoge/src/moveit_pr2/pr2_moveit_plugins/pr2_arm_kinematics/include/moveit/pr2_arm_kinematics/pr2_arm_kinematics_plugin.h:45:0,
                 from /tmp/hoge/src/moveit_pr2/pr2_moveit_plugins/pr2_arm_kinematics/src/pr2_arm_kinematics_plugin.cpp:37:
/tmp/hoge/src/moveit_pr2/pr2_moveit_plugins/pr2_arm_kinematics/include/moveit/pr2_arm_kinematics/pr2_arm_ik_solver.h:57:9: note:   because the following virtual functions are pure within ‘pr2_arm_kinematics::PR2ArmIKSolver’:
   class PR2ArmIKSolver : public KDL::ChainIkSolverPos
         ^~~~~~~~~~~~~~
In file included from /tmp/hoge/src/moveit_pr2/pr2_moveit_plugins/pr2_arm_kinematics/include/moveit/pr2_arm_kinematics/pr2_arm_ik_solver.h:42:0,
                 from /tmp/hoge/src/moveit_pr2/pr2_moveit_plugins/pr2_arm_kinematics/include/moveit/pr2_arm_kinematics/pr2_arm_kinematics_plugin.h:45,
                 from /tmp/hoge/src/moveit_pr2/pr2_moveit_plugins/pr2_arm_kinematics/src/pr2_arm_kinematics_plugin.cpp:37:
/opt/ros/melodic/include/kdl/chainiksolver.hpp:57:22: note: 	virtual void KDL::ChainIkSolverPos::updateInternalDataStructures()
         virtual void updateInternalDataStructures()=0;
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [pr2_arm_kinematics/CMakeFiles/pr2_moveit_arm_kinematics.dir/src/pr2_arm_ik_solver.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [pr2_arm_kinematics/CMakeFiles/pr2_moveit_arm_kinematics.dir/src/pr2_arm_kinematics_plugin.cpp.o] Error 1
make[1]: *** [pr2_arm_kinematics/CMakeFiles/pr2_moveit_arm_kinematics.dir/all] Error 2

```