### PR TITLE
use move_group/MoveGroupExecuteTrajectoryAction instaed of move_group/MoveGroupExecuteService

### DIFF
--- a/pr2_moveit_config/launch/move_group.launch
+++ b/pr2_moveit_config/launch/move_group.launch
@@ -41,7 +41,7 @@
     <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
 
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
 				      move_group/MoveGroupPickPlaceAction


### PR DESCRIPTION
closes

```
[ERROR] [1573817646.459257117, 2270.354000000]: Exception while loading move_group capability 'move_group/MoveGroupExecuteService': MultiLibraryClassLoader: Could not create object of class type move_group::MoveGroupExecuteService as no factory exists for it. Make sure that the library exists and was explicitly loaded through MultiLibraryClassLoader::loadLibrary()
```

error message