### PR TITLE
add pr2_moveit_plugins

### DIFF
--- a/pr2_moveit_config/package.xml
+++ b/pr2_moveit_config/package.xml
@@ -19,4 +19,5 @@
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>pr2_description</exec_depend>
+  <exec_depend>pr2_moveit_plugins</exec_depend>
 </package>


### PR DESCRIPTION
without this, we'll get
```
[ INFO] [1573818459.038512756]: Loading robot model 'pr2'...
[ WARN] [1573818459.047898726]: The root link base_footprint has an inertia specified in the URDF, but KDL does not support a root link with an inertia.  As a workaround, you can add an extra dummy link to your URDF.
[ERROR] [1573818459.052289873]: The kinematics plugin (right_arm) failed to load. Error: According to the loaded plugin descriptions the class pr2_arm_kinematics/PR2ArmKinematicsPlugin with base class type kinematics::KinematicsBase does not exist. Declared types are  cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin cached_ik_kinematics_plugin/CachedSrvKinematicsPlugin kdl_kinematics_plugin/KDLKinematicsPlugin lma_kinematics_plugin/LMAKinematicsPlugin nextage_left_arm_kinematics/IKFastKinematicsPlugin nextage_right_arm_kinematics/IKFastKinematicsPlugin srv_kinematics_plugin/SrvKinematicsPlugin trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
```

c.f. https://github.com/PR2/pr2_kinematics/pull/13
@k-okada