### PR TITLE
Removed --inorder now that it's default in melodic

### DIFF
--- a/pr2_moveit_config/launch/planning_context.launch
+++ b/pr2_moveit_config/launch/planning_context.launch
@@ -3,7 +3,7 @@
   <arg name="load_robot_description" default="false"/>
 
   <!-- Load universal robotic description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="robot_description" command="$(find xacro)/xacro '$(find pr2_description)/robots/pr2.urdf.xacro' --inorder" />
+  <param if="$(arg load_robot_description)" name="robot_description" command="$(find xacro)/xacro '$(find pr2_description)/robots/pr2.urdf.xacro'" />
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="robot_description_semantic" textfile="$(find pr2_moveit_config)/config/pr2.srdf" />

--- a/pr2_moveit_tests/kinematics/launch/pr2_jacobian_tests.launch
+++ b/pr2_moveit_tests/kinematics/launch/pr2_jacobian_tests.launch
@@ -2,10 +2,10 @@
     <arg name="kinect" default="true"/>
     <!-- send pr2 urdf to param server -->
     <group if="$(arg kinect)">
-      <param name="robot_description" command="$(find xacro)/xacro '$(find pr2_description)/robots/pr2.urdf.xacro' --inorder" />
+      <param name="robot_description" command="$(find xacro)/xacro '$(find pr2_description)/robots/pr2.urdf.xacro'" />
     </group>
     <group unless="$(arg kinect)">
-      <param name="robot_description" command="$(find xacro)/xacro '$(find pr2_description)/robots/pr2_no_kinect.urdf.xacro' --inorder" />
+      <param name="robot_description" command="$(find xacro)/xacro '$(find pr2_description)/robots/pr2_no_kinect.urdf.xacro'" />
     </group>
 
     <!-- the semantic description that corresponds to the URDF -->


### PR DESCRIPTION
One of the many messages that get output when I run a command like `roslaunch pr2_moveit_config demo.launch` is that the --inorder option for xacro is no longer needed.